### PR TITLE
Update to OWLAPI 4.0.2

### DIFF
--- a/ontology-import/pom.xml
+++ b/ontology-import/pom.xml
@@ -29,7 +29,7 @@
 	<dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
-      <version>3.3</version>
+      <version>[4.0.2,4.1)</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
This is an update to allow Snorocket to work in Protege 5 beta 18 and newer, with OWLAPI 4.0.2 and newer.
This is for local development only at this point, as OWLAPI and Protege versions have not been released yet.
